### PR TITLE
Add push button to included debug logs

### DIFF
--- a/LoraGateway.Terminal/Services/SerialProcessorService.Receive.cs
+++ b/LoraGateway.Terminal/Services/SerialProcessorService.Receive.cs
@@ -59,7 +59,8 @@ public partial class SerialProcessorService
             "PROTO-FAIL",
             "RLNC_TERMINATE",
             "DevConfStop",
-            "CRC-FAIL"
+            "CRC-FAIL",
+            "PUSH-BUTTON"
         };
         if (inclusions.Any(e => payload.Contains(e)))
         {


### PR DESCRIPTION
Calling terminate immediately made the next RLNC session fail. So with termination and adding of the coded vector things are definitely going wrong.